### PR TITLE
Change default-directory in traad-open

### DIFF
--- a/elisp/traad.el
+++ b/elisp/traad.el
@@ -84,7 +84,8 @@
          (append (if (listp traad-server-program)
                      traad-server-program
                    (list traad-server-program))
-                 (list "-V" directory))))
+                 (list "-V" directory)))
+        (default-directory "~/"))
     (apply #'start-process "traad-server" "*traad-server*" program+args)))
 
 (defun traad-close ()


### PR DESCRIPTION
This change ensures that the directory in which traad server runs
is user's home directory.

Using the normal buffer local default-directory is problem when
the files in the current directory contains something which shadows
the modules used in traad (e.g., sys.py).

Probably this matters only when using

``` cl
(setq traad-server-program '("python" "-m" "traad.server"))
```
