### PR TITLE
 rope move command

### DIFF
--- a/tests/approved/simple_move/bar.py
+++ b/tests/approved/simple_move/bar.py
@@ -1,0 +1,8 @@
+import basic.foo
+b = basic.foo.Bar()
+b.some_func()
+
+def a_free_func(a,    b,
+
+            c):
+    return a + b + c

--- a/tests/approved/simple_move/foo.py
+++ b/tests/approved/simple_move/foo.py
@@ -1,0 +1,8 @@
+class Bar:
+    def __init__(self):
+        self.foo = Foo()
+
+    def some_func(self):
+        return 1
+class Foo:
+    pass

--- a/tests/approved/simple_move/overrides.py
+++ b/tests/approved/simple_move/overrides.py
@@ -1,0 +1,7 @@
+class BaseClass:
+    def base_func(self):
+        return 1
+
+class SubClass(BaseClass):
+    def base_func(self):
+        return 2

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -1,0 +1,18 @@
+import common
+import paths
+
+
+def test_simple_move(activate_package, make_workspace):
+    activate_package(package='basic', into='main')
+    workspace = make_workspace('main')
+
+    changes = workspace.move(
+        'basic/bar.py',
+        31,
+        'basic/foo.py')
+
+    workspace.perform(changes)
+
+    common.compare_workspaces(
+        paths.approved('simple_move'),
+        paths.active('main', 'basic'))

--- a/traad/app.py
+++ b/traad/app.py
@@ -90,7 +90,7 @@ def redo_info_view(idx, context):
     }
 
 
-# TODO: COmmon exception handler decorator? Middleware?
+# TODO: Common exception handler decorator? Middleware?
 @app.post('/refactor/perform')
 def perform_view(context):
     args = bottle.request.json
@@ -163,6 +163,14 @@ def rename_view(context):
         args.get('offset'),
         args['name'])
 
+@app.post('/refactor/move')
+@standard_refactoring
+def move_view(context):
+    args = bottle.request.json
+    return context.workspace.move(
+        args['path'],
+        args.get('offset'),
+        args['dest'])
 
 @app.post('/refactor/extract_method')
 @standard_refactoring

--- a/traad/rope/workspace.py
+++ b/traad/rope/workspace.py
@@ -7,6 +7,7 @@ import rope.refactor.introduce_parameter
 import rope.refactor.localtofield
 import rope.refactor.multiproject
 import rope.refactor.rename
+import rope.refactor.move
 import rope.refactor.usefunction
 from rope.base.change import ChangeToData, DataToChange
 
@@ -150,6 +151,14 @@ class Workspace(ChangeSignatureMixin,
             self.get_resource(path),
             offset)
         return ref.get_changes(name)
+
+    @validate
+    def move(self, path, offset, dest_path):
+        ref = rope.refactor.move.create_move(
+            self.root_project,
+            self.get_resource(path),
+            offset)
+        return ref.get_changes(self.get_resource(dest_path))
 
     @validate
     def inline(self, path, offset):


### PR DESCRIPTION
Move top-level objects between files.

https://github.com/python-rope/rope/blob/master/rope/refactor/move.py

Note the "basic." in one of the tests.

I've implemented the emacs client side code for this, but not the vim code as I do not use vim for coding.

Tox test pass (but I did not run against python3.4 as it was difficult to get this working on my machine).