### PR TITLE
Flush stderr after writing server status

### DIFF
--- a/traad/bottle.py
+++ b/traad/bottle.py
@@ -3005,6 +3005,9 @@ def run(app=None, server='wsgiref', host='127.0.0.1', port=8080,
             _stderr("Bottle v%s server starting up (using %s)...\n" % (__version__, repr(server)))
             _stderr("Listening on http://%s:%d/\n" % (server.host, server.port))
             _stderr("Hit Ctrl-C to quit.\n\n")
+            # Output to stderr can get stuck in the buffer. Flush stderr
+            # to ensure the above lines are written immediately.
+            sys.stderr.flush()
 
         if reloader:
             lockfile = os.environ.get('BOTTLE_LOCKFILE')


### PR DESCRIPTION
I was running into a (rather fatal) problem where these prints to stderr were not showing up:

```
_stderr("Bottle v%s server starting up (using %s)...\n" % (__version__, repr(server)))
_stderr("Listening on http://%s:%d/\n" % (server.host, server.port))
_stderr("Hit Ctrl-C to quit.\n\n")
```

Emacs-traad relies on these lines being printed when launching a server. Since they were not printing, emacs-traad would time out whenever a command was issued, rendering it non-functional. (Spacemacs, Windows 10, fresh install of Traad and emacs-traad.)

Turns out the lines were being run, but _stderr was buffering the output. As a result, emacs-traad couldn't read the output - at least until something else caused a buffer flush (e.g. logging something). Forcing a flush after the output is sent to _stderr fixes the problem.