### PR TITLE
Add extra options for `rename_view`

### DIFF
--- a/traad/app.py
+++ b/traad/app.py
@@ -185,18 +185,10 @@ def rename_view(context):
     log.info("`rename_view` called: {}".format(args))
 
     # TODO 1: Modify "emacs-traad" to use these parameters.
-    if 'docs' in args:
-        docs = bool(args['docs'])
-    else:
-        docs = False
-    if 'unsure' in args:
-        unsure = args['unsure']
-    else:
-        unsure = None
-    if 'in_hierarchy' in args:
-        in_hierarchy = bool(args['in_hierarchy'])
-    else:
-        in_hierarchy = False
+    docs = bool(args.get('docs', False))
+    unsure = bool(args.get('unsure', False))
+    in_hierarchy = bool(args.get('in_hierarchy', False))
+
     return context.workspace.rename(
         args['path'],
         args.get('offset'),

--- a/traad/app.py
+++ b/traad/app.py
@@ -186,7 +186,7 @@ def rename_view(context):
 
     # TODO 1: Modify "emacs-traad" to use these parameters.
     docs = bool(args.get('docs', False))
-    unsure = bool(args.get('unsure', False))
+    unsure = args.get('unsure', None)
     in_hierarchy = bool(args.get('in_hierarchy', False))
 
     return context.workspace.rename(

--- a/traad/app.py
+++ b/traad/app.py
@@ -181,10 +181,29 @@ def get_imports_view(context):
 @standard_refactoring
 def rename_view(context):
     args = bottle.request.json
+
+    log.info("`rename_view` called: {}".format(args))
+
+    # TODO 1: Modify "emacs-traad" to use these parameters.
+    if 'docs' in args:
+        docs = bool(args['docs'])
+    else:
+        docs = False
+    if 'unsure' in args:
+        unsure = args['unsure']
+    else:
+        unsure = None
+    if 'in_hierarchy' in args:
+        in_hierarchy = bool(args['in_hierarchy'])
+    else:
+        in_hierarchy = False
     return context.workspace.rename(
         args['path'],
         args.get('offset'),
-        args['name'])
+        args['name'],
+        docs=docs,
+        in_hierarchy=in_hierarchy,
+        unsure=unsure)
 
 @app.post('/refactor/move')
 @standard_refactoring

--- a/traad/rope/workspace.py
+++ b/traad/rope/workspace.py
@@ -161,21 +161,22 @@ class Workspace(AutoImportMixin,
     @validate
     def rename(self, path, offset, new_name,
                in_hierarchy=False, unsure=None, docs=False):
-        """Rename the object in `path` at `offset`.
+        """Rename the object in ``path`` at ``offset``.
 
-        Parameters:
+        Args:
+          in_hierarchy: when renaming a method this keyword forces
+            to rename all matching methods in the hierarchy
+          docs: when ``True`` rename refactoring will rename
+            occurrences in comments and strings where the name is
+            visible.  Setting it will make renames faster, too.
+          unsure: decides what to do about unsure occurrences.
+            If `None`, they are ignored.  Otherwise ``unsure`` is
+            called with an instance of `occurrence.Occurrence` as
+            parameter.  If it returns `True`, the occurrence is
+            considered to be a match.
 
-         - `in_hierarchy`: when renaming a method this keyword forces
-           to rename all matching methods in the hierarchy
-         - `docs`: when `True` rename refactoring will rename
-           occurrences in comments and strings where the name is
-           visible.  Setting it will make renames faster, too.
-         - `unsure`: decides what to do about unsure occurrences.
-           If `None`, they are ignored.  Otherwise `unsure` is
-           called with an instance of `occurrence.Occurrence` as
-           parameter.  If it returns `True`, the occurrence is
-           considered to be a match.
-
+        Returns: All changes performed by the refactoring. A list of the form
+          `[[<project>, [<change set>]]`.
         """
         ref = rope.refactor.rename.Rename(
             self.root_project,

--- a/traad/rope/workspace.py
+++ b/traad/rope/workspace.py
@@ -159,12 +159,33 @@ class Workspace(AutoImportMixin,
         self.root_project.do(changes)
 
     @validate
-    def rename(self, path, offset, name):
+    def rename(self, path, offset, new_name,
+               in_hierarchy=False, unsure=None, docs=False):
+        """Rename the object in `path` at `offset`.
+
+        Parameters:
+
+         - `in_hierarchy`: when renaming a method this keyword forces
+           to rename all matching methods in the hierarchy
+         - `docs`: when `True` rename refactoring will rename
+           occurrences in comments and strings where the name is
+           visible.  Setting it will make renames faster, too.
+         - `unsure`: decides what to do about unsure occurrences.
+           If `None`, they are ignored.  Otherwise `unsure` is
+           called with an instance of `occurrence.Occurrence` as
+           parameter.  If it returns `True`, the occurrence is
+           considered to be a match.
+
+        """
         ref = rope.refactor.rename.Rename(
             self.root_project,
             self.get_resource(path),
             offset)
-        return ref.get_changes(name)
+        return ref.get_changes(
+            new_name,
+            in_hierarchy=in_hierarchy,
+            unsure=unsure,
+            docs=docs)
 
     @validate
     def move(self, path, offset, dest_path):


### PR DESCRIPTION
The Rope `rename` command takes a few optional parameters that define how it will rename occurrences. The current implementation restricts renamings to ignore docstrings, comments and occurrences higher/lower in the hierarchy (e.g. in superclasses & subclasses). It also ignores unsure occurrences. This is a small modification that exposes these options in the API so the client can specify them. 

The new parameters are optional and will default to the old values, so this won't change how this method interacts with existing clients.