### PR TITLE
Add findit functions - occurrences, implementations & definition

### DIFF
--- a/traad/app.py
+++ b/traad/app.py
@@ -382,51 +382,74 @@ def code_assist_definition_view(context):
     }
 
 
-# @app.post('/findit/occurrences')
-# def findit_occurences_view(context):
-#     args = bottle.request.json
-#     data = context.workspace.find_occurrences(
-#         args['offset'],
-#         args['path'])
+@app.get('/findit/occurrences')
+def findit_occurrences_view(context):
+    args = bottle.request.json
 
-#     # TODO: What if it actually fails?
-#     return {
-#         'result': 'success',
-#         'data': data,
-#     }
+    log.info('findit occurrences: {}'.format(args))
 
+    locations = context.workspace.find_occurrences(
+        args['offset'],
+        args['path'])
 
-# @app.post('/findit/implementations')
-# def findit_implementations_view(context):
-#     args = bottle.request.json
-#     data = context.workspace.find_implementations(
-#         args['offset'],
-#         args['path'])
-
-#     # TODO: What if it actually fails?
-#     return {
-#         'result': 'success',
-#         'data': data,
-#     }
+    if locations is None:
+        return {
+            'result': 'failure',
+            'locations': None,
+        }
+    else:
+        return {
+            'result': 'success',
+            'locations': locations,
+        }
 
 
-# @app.post('/findit/definition')
-# def findit_definitions_view(context):
-#     args = bottle.request.json
+@app.get('/findit/implementations')
+def findit_implementations_view(context):
+    args = bottle.request.json
 
-#     with open(args['path'], 'r') as f:
-#         code = f.read()
+    log.info('findit implementations: {}'.format(args))
 
-#     data = context.workspace.find_definition(
-#         code,
-#         args['offset'],
-#         args['path'])
+    locations = context.workspace.find_implementations(
+        args['offset'],
+        args['path'])
 
-#     # TODO: What if it actually fails?
-#     return {
-#         'result': 'success',
-#         'data': data,
-#     }
+    if locations is None:
+        return {
+            'result': 'failure',
+            'locations': None,
+        }
+    else:
+        return {
+            'result': 'success',
+            'locations': locations,
+        }
+
+
+@app.get('/findit/definition')
+def findit_definition_view(context):
+    args = bottle.request.json
+
+    log.info('findit definition: {}'.format(args))
+
+    with open(args['path'], 'r') as f:
+        code = f.read()
+
+    location = context.workspace.find_definition(
+        code,
+        args['offset'],
+        args['path'])
+
+    if location is None:
+        return {
+            'result': 'failure',
+            'location': None,
+        }
+    else:
+        return {
+            'result': 'success',
+            'location': location,
+        }
 
 
 @app.post("/imports/organize")

--- a/traad/rope/workspace.py
+++ b/traad/rope/workspace.py
@@ -18,6 +18,7 @@ from .extract import ExtractMixin
 from .history import HistoryMixin
 from .imports import ImportsMixin
 from .move import MoveMixin
+from .findit import FinditMixin
 from .validate import validate
 
 
@@ -48,7 +49,8 @@ class Workspace(AutoImportMixin,
                 ExtractMixin,
                 HistoryMixin,
                 ImportsMixin,
-                MoveMixin):
+                MoveMixin,
+                FinditMixin):
     """An actor that controls access to an underlying Rope project.
     """
     def __init__(self,


### PR DESCRIPTION
Add findit functions. Adds the following user-facing server functions:

- `findit_occurrences_view`
- `findit_implementations_view`
- `findit_definition_view`

They each return location data in a series of dictionaries. There was a commented-out implementation that returned location data as a series of tuples. This has been removed in favour of a dict-based approach. Dictionaries make the data being transferred clearer (and are more robust to a change in the structure of the API). 

I've also written an Emacs implementation which takes advantage of these functions [here](https://github.com/jcaw/emacs-traad/tree/findit). The code is a little convoluted but the result seems reliable. I can clean it up before opening a pull request, if you like it. Here's an example of the output of `traad-find-occurrences`:

_(Command called on `args` in `extract_variable_view`)_

![traad_find_occurrences](https://user-images.githubusercontent.com/40725916/42550171-e94f19ba-8484-11e8-834b-d9850293c8f8.png)