### PR TITLE
Add codeassist.find_definition_location

### DIFF
--- a/traad/app.py
+++ b/traad/app.py
@@ -374,8 +374,11 @@ def code_assist_definition_view(context):
 
     log.info('get definition: {}'.format(args))
 
-    with open(args['path'], 'r') as f:
-        code = f.read()
+    if 'code' in args:
+        code = args['code']
+    else:
+        with open(args['path'], 'r') as f:
+            code = f.read()
 
     definition, line = context.workspace.get_definition_location(
         code=code,

--- a/traad/app.py
+++ b/traad/app.py
@@ -368,18 +368,36 @@ def code_assist_calltip_view(context):
     }
 
 
-@app.get('/code_assist/definition')
+@app.post('/code_assist/definition')
 def code_assist_definition_view(context):
     args = bottle.request.json
 
     log.info('get definition: {}'.format(args))
 
-    return {
-        'results': context.workspace.get_definition_location(
-            code=args['code'],
-            offset=args['offset'],
-            path=args['path'])
-    }
+    with open(args['path'], 'r') as f:
+        code = f.read()
+
+    definition, line = context.workspace.get_definition_location(
+        code=code,
+        offset=args['offset'],
+        path=args['path'])
+
+    if definition is None:
+        return {
+            'result': "failure",
+            'realpath': None,
+            'path': None,
+            'name': None,
+            'lineno': None,
+        }
+    else:
+        return {
+            'result': "success",
+            'realpath': definition.real_path,
+            'path': definition.path,
+            'name': definition.name,
+            'lineno': line,
+        }
 
 
 # @app.post('/findit/occurrences')

--- a/traad/rope/code_assist.py
+++ b/traad/rope/code_assist.py
@@ -76,3 +76,25 @@ class CodeAssistMixin:
             code,
             offset,
             self.get_resource(path))
+
+    @validate
+    def get_definition_location(self, code, offset, path):
+        """Get the definition location of a function.
+
+        ``path`` may be absolute or relative. If ``path`` is relative,
+        then it must be relative to the root of the project.
+
+        Args:
+          code: The source code.
+          offset: An offset into ``code`` of the object to query.
+          path: The path to the resource in which the search is
+            being done.
+
+        Returns: A (`rope.base.resources.Resource`, lineno) tuple.
+        """
+
+        return rope.contrib.codeassist.get_definition_location(
+            self.root_project,
+            code,
+            offset,
+            self.get_resource(path))


### PR DESCRIPTION
Add an interface to allow clients to find where objects are defined.

A method stub for the server command already existed - this extends it to add full
functionality. One note is that the old method stub was written to return the
results of the Rope operation directly (this would fail as they can't be directly 
converted into json). The new method returns a dictionary of the form:

```
{
    'result': value,
    'realpath': value,
    'path': value,
    'name': value,
    'lineno': value,
}
```

I was able to find two different functions within Rope that locate definitions. The `findit` module has one, and the `code_assist` module has another. This uses the function from the `code_assist` module. 

I have also added an interface for this in `emacs-traad`. The branch is available [here](https://github.com/jcaw/emacs-traad/tree/goto-definition) - I'll request a pull there too if this is accepted.