### PR TITLE
Bump version to include findit functionality

### DIFF
--- a/traad/version.py
+++ b/traad/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (3, 1, 1)
+__version_info__ = (3, 2, 0)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
Just ran into a bug installing directly from Pip - looks like PyPI is carrying an old version. The last release on PyPI is [3.1.1, released May 6th](https://pypi.org/project/traad/3.1.1/#history). Five PRs have been made since then (#101 to #105), and the Emacs package now uses these. Up until now I've been compiling from source, so I missed this one. 

I'm not sure what the version bumping scheme looks like - how does this sound?