### PR TITLE
Fix import error for Python 3.10

### DIFF
--- a/traad/bottle.py
+++ b/traad/bottle.py
@@ -82,7 +82,10 @@ if py3k:
     from urllib.parse import urlencode, quote as urlquote, unquote as urlunquote
     urlunquote = functools.partial(urlunquote, encoding='latin1')
     from http.cookies import SimpleCookie
-    from collections import MutableMapping as DictMixin
+    try:
+        from collections.abc import MutableMapping as DictMixin
+    except ImportError:
+        from collections import MutableMapping as DictMixin
     import pickle
     from io import BytesIO
     from configparser import ConfigParser


### PR DESCRIPTION
Hi Austin,

Thank you for your work that you have been putting into this tool.

Recently, I've upgrade to Python 3.10 and it requires that the MutableMapping be imported from collections.abc

I've update this to work with 3.10 and thought I would provide it back to help others.

Thank you again!